### PR TITLE
Enable final merge with method: merge

### DIFF
--- a/src/autorebase.ts
+++ b/src/autorebase.ts
@@ -128,7 +128,7 @@ const merge = async ({
 }): Promise<MergeAction> => {
   debug("merging", pullRequestNumber);
   await octokit.pulls.merge({
-    merge_method: "rebase",
+    merge_method: process.env.MERGE_METHOD || "rebase",
     number: pullRequestNumber,
     owner,
     repo,


### PR DESCRIPTION
Hi!

We would like to merge the final merge (sorry about so many merges :) with a merge method instead of a rebase method.

Choosing the merge method with an environment variable looks useful to you?

Thanks a lot for autorebase!!

-- Gaizka