### PR TITLE
Fix fetching pull request numbers

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -187,8 +187,13 @@ const getPullRequestInfoWithKnownMergeableState = async ({
   });
 };
 
-const getPullRequestNumbers = (searchResults: any): PullRequestNumber[] =>
-  searchResults.items.map((item: any) => item.number);
+const getPullRequestNumbers = (searchResults: any): PullRequestNumber[] => {
+    if (searchResults["items"]) {
+        return searchResults.items.map((item: any) => item.number);
+    } else {
+        return searchResults.number;
+    }
+}
 
 const findOldestPullRequest = async ({
   debug,


### PR DESCRIPTION
Sometimes, at least in our repo, searchResults.items do not exist.